### PR TITLE
introduce service module to access data services

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -25,6 +25,7 @@ import {
   AppPluginStartDependencies,
   AppPluginSetuoDependencies,
 } from './types';
+import { setData } from './services';
 
 
 export class TagsSearchPublicPlugin
@@ -55,7 +56,9 @@ export class TagsSearchPublicPlugin
     });
   }
 
-  public start(core: CoreStart): TagsSearchPluginStart {}
+  public start(core: CoreStart, plugins: any): TagsSearchPluginStart {
+    setData(plugins.data);
+  }
   public stop() {}
 }
 

--- a/public/services.ts
+++ b/public/services.ts
@@ -1,0 +1,6 @@
+import { createGetterSetter } from '../../../../src/plugins/kibana_utils/public';
+
+
+export const [getData, setData] = createGetterSetter<any>(
+    'Data'
+  );

--- a/public/tag_search_vis/tag_search_components.tsx
+++ b/public/tag_search_vis/tag_search_components.tsx
@@ -23,6 +23,7 @@ import rison from 'rison-node';
 import {
 	DataPublicPluginStart,
 } from '../../../../src/plugins/data/public';
+import { getData } from '../services';
 
 let allOptions = []
 let arr3 = [];
@@ -96,10 +97,10 @@ interface TagsSearchComponentDeps {
 	visParams: {
 		counter: number;
 	};
-	data: DataPublicPluginStart
 }
 
 export const TagsSearchComponent = (props: TagsSearchComponentDeps) => {
+	const data = getData();
 
 
 	useEffect(() => {
@@ -111,7 +112,7 @@ export const TagsSearchComponent = (props: TagsSearchComponentDeps) => {
 
 	const onChange = (selectedOptions) => {
 		setSelected(selectedOptions);
-		console.log("FILTERS:: ", props.data.query.filterManager.getFilters())
+		console.log("FILTERS:: ", data.query.filterManager.getFilters())
 	};
 
 	const onCreateOption = (searchValue, flattenedOptions = []) => {


### PR DESCRIPTION
This PR makes data services accessible in your component in the same way the data plugin uses internally: https://github.com/elastic/kibana/blob/7.10/src/plugins/data/public/services.ts

In the `start` method of your plugin it's storing the reference in the services module which can be accessed directly from within your component.

I didn't test it, let me know whether it works.